### PR TITLE
added a check for online/offline status and activate call on coming back

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7352,7 +7352,7 @@ dependencies = [
 [[package]]
 name = "sugarfunge-api-types"
 version = "0.1.0"
-source = "git+https://github.com/functionland/sugarfunge-api.git?rev=1bbc8b26656d5297a6fc799e473f502e7bb6c99e#1bbc8b26656d5297a6fc799e473f502e7bb6c99e"
+source = "git+https://github.com/functionland/sugarfunge-api.git?rev=3dfe375a4e3d3762b33fba2aaeef3e97ee6455c5#3dfe375a4e3d3762b33fba2aaeef3e97ee6455c5"
 dependencies = [
  "bevy_derive 0.12.1",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ crossbeam = "0.8"
 ipfs-api-backend-hyper = { version = "0.5.0" }
 
 reqwest = { version = "0.11", features = ["json"] }
-sugarfunge-api-types = { git = "https://github.com/functionland/sugarfunge-api.git", rev = "1bbc8b26656d5297a6fc799e473f502e7bb6c99e" }
+sugarfunge-api-types = { git = "https://github.com/functionland/sugarfunge-api.git", rev = "3dfe375a4e3d3762b33fba2aaeef3e97ee6455c5" }
 contract-api-types = {git = "https://github.com/functionland/fula-contract-api.git", rev = "00c23786bdaf0c60ec601d8b1207c52fa49d7947"}
 pcd-rs = "0.8.0"
 bytes = "1.1"

--- a/src/sugarfunge.rs
+++ b/src/sugarfunge.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::time;
 use structopt::StructOpt;
-use sugarfunge_api_types::{account::*, challenge::*, fula::*, primitives::*, *};
+use sugarfunge_api_types::{account::*, challenge::*, fula::*, primitives::*, validator::*,*};
 
 #[derive(Deref)]
 pub struct Sender<T>(pub channel::Sender<T>);
@@ -430,11 +430,11 @@ pub fn launch(tokio_runtime: Res<TokioRuntime>) {
                                 let account_tmp: Account = seeded.account.clone();
                                 let validator_activate_req = validator::AddValidatorInput {
                                     seed: seeded.seed.clone(),
-                                    validator_id: account_tmp,
+                                    validator_id: String::from(&account_tmp).into(),
                                 };
-                                let result = fula_sugarfunge_req("validator/activate", validator_activate_req).await;
+                                let result = activate_validator(validator_activate_req).await;
                                 match result {
-                                    Ok(output) if output.validator_id == account_tmp => {
+                                    Ok(output) => {
                                         // Successfully activated the validator, proceed as normal.
                                         was_node_online = true;
                                     },
@@ -647,6 +647,14 @@ pub async fn calculate_rewards(
         }
     }
     return rewards;
+}
+
+async fn activate_validator(
+    input: AddValidatorInput,
+) -> Result<AddValidatorOutput, RequestError> {
+    let result: Result<AddValidatorOutput, _> =
+        fula_sugarfunge_req("validator/activate", input).await;
+    return result;
 }
 
 async fn convert_to_validator(

--- a/src/sugarfunge.rs
+++ b/src/sugarfunge.rs
@@ -415,6 +415,7 @@ pub fn launch(tokio_runtime: Res<TokioRuntime>) {
                 let mut log_info = LogInfo{ day: 0, cycle: 0, status: Status::NotApproved, additional_info: "Validator Not Approved".into() };
 
                 for cycle in 1..config.total_cyles {
+                    let mut daily_rewards = 0.0;
                     log_info.day = cycle / config.cycles_advance as u64;
                     log_info.cycle = cycle;
                     // Check the current online status of the node.
@@ -480,7 +481,6 @@ pub fn launch(tokio_runtime: Res<TokioRuntime>) {
                                 log_info.status = Status::Online;
                                 log_info.additional_info = "Validator Ok".into();
                             }
-                            let mut daily_rewards = 0.0;
         
                             // Get the current pool_id of the user
                             let pool_id = get_account_pool_id(seeded.account.clone()).await;
@@ -586,9 +586,12 @@ pub fn launch(tokio_runtime: Res<TokioRuntime>) {
                                     }
                                 }
                             }
-                            print_log_info(&log_info,daily_rewards,config.time_between_cycles_miliseconds).await;
                         }
+                    } else {
+                        log_info.status = Status::Offline;
+                        log_info.additional_info = "Couldn't reach the API".into();
                     }
+                    print_log_info(&log_info,daily_rewards,config.time_between_cycles_miliseconds).await;
                 }
             }
         });

--- a/src/sugarfunge.rs
+++ b/src/sugarfunge.rs
@@ -1,6 +1,9 @@
 use crate::{common::TokioRuntime, config, opts::Opt};
 use bevy::prelude::*;
-use contract_api_types::{config::Config, calls::{ConvertToValidatorInput, ConvertToValidatorOutput}};
+use contract_api_types::{
+    calls::{ConvertToValidatorInput, ConvertToValidatorOutput},
+    config::Config,
+};
 use crossbeam::channel;
 use dotenv::dotenv;
 use ipfs_api::IpfsApi;
@@ -9,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::time;
 use structopt::StructOpt;
-use sugarfunge_api_types::{account::*, challenge::*, fula::*, primitives::*, validator::*,*};
+use sugarfunge_api_types::{account::*, challenge::*, fula::*, primitives::*, validator::*, *};
 
 #[derive(Deref)]
 pub struct Sender<T>(pub channel::Sender<T>);
@@ -20,6 +23,22 @@ pub struct Receiver<T>(pub channel::Receiver<T>);
 pub struct RequestError {
     pub message: serde_json::Value,
     pub description: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum Status {
+    Online,
+    Offline,
+    NotApproved
+}
+
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LogInfo {
+    pub day: u64,
+    pub cycle: u64,
+    pub status: Status,
+    pub additional_info: String,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -337,22 +356,18 @@ async fn verify_asset_info(class_id: ClassId, asset_id: AssetId, seeded_seed: Se
         info!("CREATION: created: {:#?}", create_asset);
     }
 }
-async fn is_node_online() -> Result<bool, RequestError> {
-    let client = reqwest::Client::new();
-    let url = "https://ping.node3.functionyard.fula.network";
-    match client.head(url).send().await {
-        Ok(response) => {
-            // Assuming that a successful response indicates the node is online.
-            // You might need to adjust the logic based on the actual API behavior.
-            Ok(response.status().is_success())
-        },
-        Err(e) => Err(RequestError {
-            message: json!(format!("{:#?}", e)),
-            description: "Node status check failed.".into(),
-        }),
-    }
-}
 
+async fn print_log_info(info: &LogInfo, rewards: f64, time:u64){
+    println!(
+        "DAY: {} CYCLE: {} REWARDS: {}  STATUS:{:#?}  INFO: {}",
+        info.day,
+        info.cycle,
+        rewards,
+        info.status,
+        info.additional_info
+    );
+    tokio::time::sleep(time::Duration::from_millis(time)).await;
+}
 
 pub fn launch(tokio_runtime: Res<TokioRuntime>) {
     let rt = tokio_runtime.runtime.clone();
@@ -362,7 +377,7 @@ pub fn launch(tokio_runtime: Res<TokioRuntime>) {
         rt.block_on(async move {
             let cmd_opts = Opt::from_args();
 
-            if let Ok (config) = setup().await {
+            if let Ok(config) = setup().await {
                 let class_id_labor = ClassId::from(config.labor_token_class_id);
                 let asset_id_labor = AssetId::from(config.labor_token_class_id);
                 let class_id_challenge = ClassId::from(config.challenge_token_class_id);
@@ -397,183 +412,182 @@ pub fn launch(tokio_runtime: Res<TokioRuntime>) {
                 info!("VERIFICATION: User Seed {:?}", seeded.seed);
                 info!("VERIFICATION: User Account {:?}", seeded.account);
 
-                if let Ok(_) = convert_to_validator(ConvertToValidatorInput { seed: seeded.seed.to_string(), aura_account: cmd_opts.aura.to_string(), grandpa_account: cmd_opts.grandpa.to_string() }).await{
-                    register_account(seeded.account.clone()).await;
-                    verify_class_info(class_id_labor, seeded.seed.clone(), seeded.account.clone()).await;
+                let mut log_info = LogInfo{ day: 0, cycle: 0, status: Status::NotApproved, additional_info: "Validator Not Approved".into() };
 
-                    verify_asset_info(class_id_labor, asset_id_labor, seeded.seed.clone()).await;
-    
-                    verify_class_info(
-                        class_id_challenge,
-                        seeded.seed.clone(),
-                        seeded.account.clone(),
-                    )
-                    .await;
-    
-                    verify_asset_info(class_id_challenge, asset_id_challenge, seeded.seed.clone()).await;
-    
-                    //Executing the Calculation, Mint and Update of rewards
-                    let mut was_node_online = false;
-    
-                    for cycle in 1..config.total_cyles {
-                        // Check the current online status of the node.
-                        let is_online = match is_node_online().await {
-                            Ok(status) => status,
-                            Err(e) => {
-                                // Handle the error (e.g., by logging or retrying later).
-                                eprintln!("Error checking node status: {:?}", e);
-                                continue; // Skip this cycle or handle as needed.
+                for cycle in 1..config.total_cyles {
+                    log_info.day = cycle / config.cycles_advance as u64;
+                    log_info.cycle = cycle;
+                    // Check the current online status of the node.
+                    if let Ok(is_online) = is_validator_online(IsValidatorInput {
+                        account: seeded.account.clone(),
+                    })
+                    .await
+                    {
+                        if !is_online.approved {
+                            if let Ok(_) = convert_to_validator(ConvertToValidatorInput {
+                                seed: seeded.seed.to_string(),
+                                aura_account: cmd_opts.aura.to_string(),
+                                grandpa_account: cmd_opts.grandpa.to_string(),
+                            })
+                            .await
+                            {
+                                log_info.status = Status::Online;
+                                log_info.additional_info = "Validator Approved".into();
+                                register_account(seeded.account.clone()).await;
+                                verify_class_info(
+                                    class_id_labor,
+                                    seeded.seed.clone(),
+                                    seeded.account.clone(),
+                                )
+                                .await;
+
+                                verify_asset_info(
+                                    class_id_labor,
+                                    asset_id_labor,
+                                    seeded.seed.clone(),
+                                )
+                                .await;
+
+                                verify_class_info(
+                                    class_id_challenge,
+                                    seeded.seed.clone(),
+                                    seeded.account.clone(),
+                                )
+                                .await;
+
+                                verify_asset_info(
+                                    class_id_challenge,
+                                    asset_id_challenge,
+                                    seeded.seed.clone(),
+                                )
+                                .await;
                             }
-                        };
-                        if is_online {
-                            if !was_node_online {
-                                let account_tmp: Account = seeded.account.clone();
-                                let validator_activate_req = validator::AddValidatorInput {
-                                    seed: seeded.seed.clone(),
-                                    validator_id: String::from(&account_tmp).into(),
-                                };
-                                let result = activate_validator(validator_activate_req).await;
-                                match result {
-                                    Ok(output) => {
-                                        // Successfully activated the validator, proceed as normal.
-                                        was_node_online = true;
-                                    },
-                                    _ => {
-                                        // Failed to activate the validator, consider the node as still offline.
-                                        was_node_online = false;
-                                        println!(
-                                            "DAY: {} CYCLE: {} Was offline, activation failed.",
-                                            cycle / config.cycles_advance as u64,
-                                            cycle
-                                        );
-                                        tokio::time::sleep(time::Duration::from_millis(config.time_between_cycles_miliseconds)).await;
-                                        continue;
-                                    }
-                                }
-                            }
+                            print_log_info(&log_info,0.0,config.time_between_cycles_miliseconds).await;
                         } else {
-                            was_node_online = false;
-                            println!(
-                                "DAY: {} CYCLE: {} Was offline",
-                                cycle / config.cycles_advance as u64,
-                                cycle
-                            );
-                            tokio::time::sleep(time::Duration::from_millis(config.time_between_cycles_miliseconds)).await;
-                            continue;
-                        }
-                        let mut daily_rewards = 0.0;
-    
-                        // Get the current pool_id of the user
-                        let pool_id = get_account_pool_id(seeded.account.clone()).await;
-    
-                        // Validate the manifests of the user on-chain, also the invalid manifests are going to be remove from the chain
-                        let user_manifests = validate_current_manifests(VerifyManifestsInput {
-                            seed: seeded.seed.clone(),
-                        })
-                        .await;
-                        info!("STEP 1: VERIFY USER MANIFESTS {:#?}", user_manifests);
-    
-                        // Verify if there is a file in the chain storage that the user is storaging where the size is unknown on-chain
-                        if let Ok(verify_file_size_response) = verify_file_size(VerifyFileSizeInput {
-                            account: seeded.account.clone(),
-                        })
-                        .await
-                        {
-                            if verify_file_size_response.cids.len() > 0 {
-                                let result = get_file_sizes(verify_file_size_response.cids).await;
-                                if let Some(pool_id) = pool_id {
-                                    let _result = provide_file_size(ProvideFileSizeInput {
+                            if is_online.offline {
+                                    log_info.status = Status::Offline;
+                                    if let Ok(_) = activate_validator(AddValidatorInput{
                                         seed: seeded.seed.clone(),
-                                        pool_id,
-                                        cids: result.0,
-                                        sizes: result.1,
-                                    })
-                                    .await;
-                                };
+                                        validator_id: String::from(&seeded.account.clone()).into(),
+                                    }).await{
+                                        log_info.status = Status::Online;
+                                        log_info.additional_info = "Validator Activated".into();
+                                    } else {
+                                        log_info.additional_info = "Activation Failed".into();
+                                        print_log_info(&log_info,0.0,config.time_between_cycles_miliseconds).await;
+                                    }
+                            } else {
+                                log_info.status = Status::Online;
+                                log_info.additional_info = "Validator Ok".into();
                             }
-                        }
-    
-                        // Verify if there is an Open challenge for the user, if there is a challenge verify the cid content of the user
-                        if let Ok(verify_pending_challenge_response) =
-                            verify_pending_challenge(VerifyPendingChallengeInput {
+                            let mut daily_rewards = 0.0;
+        
+                            // Get the current pool_id of the user
+                            let pool_id = get_account_pool_id(seeded.account.clone()).await;
+        
+                            // Validate the manifests of the user on-chain, also the invalid manifests are going to be remove from the chain
+                            let user_manifests = validate_current_manifests(VerifyManifestsInput {
+                                seed: seeded.seed.clone(),
+                            })
+                            .await;
+                            info!("STEP 1: VERIFY USER MANIFESTS {:#?}", user_manifests);
+        
+                            // Verify if there is a file in the chain storage that the user is storaging where the size is unknown on-chain
+                            if let Ok(verify_file_size_response) = verify_file_size(VerifyFileSizeInput {
                                 account: seeded.account.clone(),
                             })
                             .await
-                        {
-                            if verify_pending_challenge_response.pending {
-                                if let Some(pool_id) = pool_id {
-                                    if let Ok(value) = get_manifests_storage_data(
-                                        Some(pool_id),
-                                        Some(seeded.account.clone()),
-                                    )
-                                    .await
-                                    {
-                                        let _result = verify_challenge(VerifyChallengeInput {
+                            {
+                                if verify_file_size_response.cids.len() > 0 {
+                                    let result = get_file_sizes(verify_file_size_response.cids).await;
+                                    if let Some(pool_id) = pool_id {
+                                        let _result = provide_file_size(ProvideFileSizeInput {
                                             seed: seeded.seed.clone(),
-                                            pool_id: pool_id,
-                                            cids: get_vec_cid_from_manifest_storer_data(value.manifests),
-                                            class_id: class_id_challenge,
-                                            asset_id: asset_id_challenge,
+                                            pool_id,
+                                            cids: result.0,
+                                            sizes: result.1,
                                         })
                                         .await;
-                                    }
-                                };
-                            }
-                        }
-    
-                        // Generate a random challenge each cycle
-                        if let Ok(generated_challenge) = generate_challenge(GenerateChallengeInput {
-                            seed: seeded.seed.clone(),
-                        })
-                        .await
-                        {
-                            info!("STEP 2: GENERATED CHALLENGE {:#?}", generated_challenge);
-                        } else {
-                            info!("STEP 2: NO ACCOUNTS TO CHALLENGE");
-                        }
-    
-                        // Get all the manifests from the network on-chain
-                        let all_manifests = get_manifests(None, None, None).await;
-    
-                        // Verify that the Result is the expected value
-                        if let Ok(current_all_manifests) = all_manifests {
-                            // If there are no manifest in the network the calculation is skipped
-                            if current_all_manifests.manifests.len() > 0 {
-                                // Get the cummulative size of all the network manifets
-                                let network_size = get_cumulative_size(&current_all_manifests).await as f64;
-    
-                                // Calculate the labor tokens corresponded for the user
-                                let rewards = calculate_daily_rewards(config.clone(), network_size, &seeded).await;
-    
-                                info!("STEP 3: CALCULATE REWARDS:");
-                                info!("  Mining Rewards: {:?}", rewards.daily_mining_rewards);
-                                info!("  Storage Rewards: {:?}", rewards.daily_storage_rewards);
-    
-                                daily_rewards += rewards.daily_storage_rewards;
-                                daily_rewards += rewards.daily_mining_rewards;
-    
-                                //MINT DAILY REWARDS
-                                if let Some(_pool_id) = pool_id {
-                                    let mint = mint_labor_tokens(MintLaborTokensInput {
-                                        seed: seeded.seed.clone(),
-                                        amount: Balance::try_from(daily_rewards as u128).unwrap(),
-                                        class_id: class_id_labor,
-                                        asset_id: asset_id_labor,
-                                    })
-                                    .await;
-                                    info!("STEP 4: MINT LABOR TOKENS: {:#?}", mint);
-                                } else {
-                                    info!("STEP 4: ERROR WHEN TRIED TO MINT LABOR TOKENS: INVALID POOL_ID");
+                                    };
                                 }
                             }
+        
+                            // Verify if there is an Open challenge for the user, if there is a challenge verify the cid content of the user
+                            if let Ok(verify_pending_challenge_response) =
+                                verify_pending_challenge(VerifyPendingChallengeInput {
+                                    account: seeded.account.clone(),
+                                })
+                                .await
+                            {
+                                if verify_pending_challenge_response.pending {
+                                    if let Some(pool_id) = pool_id {
+                                        if let Ok(value) = get_manifests_storage_data(
+                                            Some(pool_id),
+                                            Some(seeded.account.clone()),
+                                        )
+                                        .await
+                                        {
+                                            let _result = verify_challenge(VerifyChallengeInput {
+                                                seed: seeded.seed.clone(),
+                                                pool_id: pool_id,
+                                                cids: get_vec_cid_from_manifest_storer_data(value.manifests),
+                                                class_id: class_id_challenge,
+                                                asset_id: asset_id_challenge,
+                                            })
+                                            .await;
+                                        }
+                                    };
+                                }
+                            }
+        
+                            // Generate a random challenge each cycle
+                            if let Ok(generated_challenge) = generate_challenge(GenerateChallengeInput {
+                                seed: seeded.seed.clone(),
+                            })
+                            .await
+                            {
+                                info!("STEP 2: GENERATED CHALLENGE {:#?}", generated_challenge);
+                            } else {
+                                info!("STEP 2: NO ACCOUNTS TO CHALLENGE");
+                            }
+        
+                            // Get all the manifests from the network on-chain
+                            let all_manifests = get_manifests(None, None, None).await;
+        
+                            // Verify that the Result is the expected value
+                            if let Ok(current_all_manifests) = all_manifests {
+                                // If there are no manifest in the network the calculation is skipped
+                                if current_all_manifests.manifests.len() > 0 {
+                                    // Get the cummulative size of all the network manifets
+                                    let network_size = get_cumulative_size(&current_all_manifests).await as f64;
+        
+                                    // Calculate the labor tokens corresponded for the user
+                                    let rewards = calculate_daily_rewards(config.clone(), network_size, &seeded).await;
+        
+                                    info!("STEP 3: CALCULATE REWARDS:");
+                                    info!("  Mining Rewards: {:?}", rewards.daily_mining_rewards);
+                                    info!("  Storage Rewards: {:?}", rewards.daily_storage_rewards);
+        
+                                    daily_rewards += rewards.daily_storage_rewards;
+                                    daily_rewards += rewards.daily_mining_rewards;
+        
+                                    //MINT DAILY REWARDS
+                                    if let Some(_pool_id) = pool_id {
+                                        let mint = mint_labor_tokens(MintLaborTokensInput {
+                                            seed: seeded.seed.clone(),
+                                            amount: Balance::try_from(daily_rewards as u128).unwrap(),
+                                            class_id: class_id_labor,
+                                            asset_id: asset_id_labor,
+                                        })
+                                        .await;
+                                        info!("STEP 4: MINT LABOR TOKENS: {:#?}", mint);
+                                    } else {
+                                        info!("STEP 4: ERROR WHEN TRIED TO MINT LABOR TOKENS: INVALID POOL_ID");
+                                    }
+                                }
+                            }
+                            print_log_info(&log_info,daily_rewards,config.time_between_cycles_miliseconds).await;
                         }
-                        println!(
-                            "DAY: {} CYCLE: {} REWARDS: {}",
-                            cycle / config.cycles_advance as u64,
-                            cycle,
-                            daily_rewards
-                        );
-                        tokio::time::sleep(time::Duration::from_millis(config.time_between_cycles_miliseconds)).await;
                     }
                 }
             }
@@ -649,9 +663,13 @@ pub async fn calculate_rewards(
     return rewards;
 }
 
-async fn activate_validator(
-    input: AddValidatorInput,
-) -> Result<AddValidatorOutput, RequestError> {
+async fn is_validator_online(input: IsValidatorInput) -> Result<IsValidatorOutput, RequestError> {
+    let result: Result<IsValidatorOutput, _> =
+        fula_sugarfunge_req("validator/is_online", input).await;
+    return result;
+}
+
+async fn activate_validator(input: AddValidatorInput) -> Result<AddValidatorOutput, RequestError> {
     let result: Result<AddValidatorOutput, _> =
         fula_sugarfunge_req("validator/activate", input).await;
     return result;
@@ -665,10 +683,8 @@ async fn convert_to_validator(
     return result;
 }
 
-async fn setup(
-) -> Result<Config, RequestError> {
-    let result: Result<Config, _> =
-        fula_contract_req("setup", ()).await;
+async fn setup() -> Result<Config, RequestError> {
+    let result: Result<Config, _> = fula_contract_req("setup", ()).await;
     return result;
 }
 


### PR DESCRIPTION
We need to add a call to activate endpoint when the node comes back online to be re-added to validator set.
before each cycle, it checks if the node is_online and if it was_online, and when the status changes from offline to online it calls activate and if the status is offline it skips that cycle.
Being online is checked with a ping header to node.functionyard.fula.network and below is the conditions:
1- was_online and is_online => continue as normal to the cycle
2- !is_online => skip the cycle
3- !was_online and is_online => call activate endpoint and if a success then continue in the cycle otherwise skip the cycle and keep the was_online status as offline for the next cycle to recall the activate